### PR TITLE
Add more complex matrix usage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,20 +20,15 @@ jobs:
 
     strategy:
       matrix:
+        os: ["windows-latest", "ubuntu-latest", "macos-latest"]
+        python-version: ["3.8", "3.9", "3.10"]
+        my_custom_flag: [false]
         include:
           - os: ubuntu-latest
-            label: linux-64
-            prefix: /usr/share/miniconda3/envs/my-env
+            python-version: "3.10"
+            my_custom_flag: true
 
-          - os: macos-latest
-            label: osx-64
-            prefix: /Users/runner/miniconda3/envs/my-env
-
-          - os: windows-latest
-            label: win-64
-            prefix: C:\Miniconda3\envs\my-env
-
-    name: ${{ matrix.label }}
+    name: ${{ matrix.os }}-${{ matrix.python-version }}-${{ matrix.my_custom_flag }}
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2
@@ -45,14 +40,19 @@ jobs:
             miniforge-version: latest
             activate-environment: my-env
             use-mamba: true
+            python-version: ${{ matrix.python-version }}
 
-      - name: Set cache date
-        run: echo "DATE=$(date +'%Y%m%d')" >> $GITHUB_ENV
+      - name: Set cache environment variables
+        shell: bash -l {0}
+        run: |
+          echo "DATE=$(date +'%Y%m%d')" >> $GITHUB_ENV
+          CONDA_PREFIX=$(python -c "import sys; print(sys.prefix)")
+          echo "CONDA_PREFIX=$CONDA_PREFIX" >> $GITHUB_ENV
 
       - uses: actions/cache@v2
         with:
-          path: ${{ matrix.prefix }}
-          key: ${{ matrix.label }}-conda-${{ hashFiles('environment.yml') }}-${{ env.DATE }}-${{ env.CACHE_NUMBER }}
+          path: ${{ env.CONDA_PREFIX }}
+          key: ${{ matrix.os }}-${{ matrix.python-version }}-conda-${{ hashFiles('environment.yml') }}-${{ env.DATE }}-${{ matrix.experimental }}-${{ env.CACHE_NUMBER }}
         id: cache
 
       - name: Update environment
@@ -62,3 +62,4 @@ jobs:
       - name: Run tests
         shell: bash -l {0}
         run: pytest ./tests
+


### PR DESCRIPTION
Closes #3 

This PR rewrites the main workflow file to use a more complex build matrix and simplifies what information the user/developer needs to know to prepare the cache. This type of matrix is not possible with the current example since it depends on the label and prefix being specified for each iteration of the matrix build. The label (at least for me) is just aesthetics and the prefix can be retrieved by running python itself which is what I do here.

This new workflow also shows how you could specify a custom option in your matrix that you use later. In my real world case I have an unstable/experimental environment where I take a normal conda install and then pip install a couple dependencies directly from github source. As far as I understand github's caching, the caching of the initial version happens at the end of all of the steps and would include the installation of the unstable packages. By including the custom flag in the cache key this avoids the unstable environment corrupting another environment for a different matrix run.